### PR TITLE
[Bug fix] Fix handlers initialization

### DIFF
--- a/scamper/scamper.c
+++ b/scamper/scamper.c
@@ -491,13 +491,13 @@ static int check_options(int argc, char *argv[])
   uint32_t o;
 
   for(m=0; m<sizeof(multicall)/sizeof(scamper_multicall_t); m++)
-  {
-    len = strlen(multicall[m].argv0);
-    if(argv0 >= len && strcmp(argv[0]+argv0-len, multicall[m].argv0) == 0)
     {
-      return multicall_do(&multicall[m], argc, argv);
+      len = strlen(multicall[m].argv0);
+      if(argv0 >= len && strcmp(argv[0]+argv0-len, multicall[m].argv0) == 0)
+	{
+	  return multicall_do(&multicall[m], argc, argv);
+	}
     }
-  }
 
   off = 0;
   string_concat(opts, sizeof(opts), &off, "c:C:e:fF:iIl:L:M:o:O:p:P:R:vw:?");
@@ -1181,16 +1181,16 @@ static int scamper(int argc, char *argv[])
   int                      rc;
 
   if(check_options(argc, argv) == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
 #ifdef HAVE_DAEMON
   if((options & OPT_DAEMON) != 0 && daemon(1, 0) != 0)
-  {
-    printerror(__func__, "could not daemon");
-    return -1;
-  }
+    {
+      printerror(__func__, "could not daemon");
+      return -1;
+    }
 #endif
 
   scamper_debug_init();
@@ -1211,9 +1211,9 @@ static int scamper(int argc, char *argv[])
    * version compatibility
    */
   if(scamper_dl_init() == -1)
-  {
+    {
       return -1;
-  }
+    }
 
 #ifdef HAVE_OPENSSL
   if((flags & FLAG_NOTLS) == 0)
@@ -1221,32 +1221,32 @@ static int scamper(int argc, char *argv[])
 #endif
 
 #ifndef WITHOUT_PRIVSEP
-  /* revoke the root privileges we started with */
+  /* revoke the root priviledges we started with */
   if(scamper_privsep_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 #endif
 
   random_seed();
 
   if(firewall != NULL)
-  {
-    if(scamper_firewall_init(firewall) != 0)
-	  return -1;
-    free(firewall);
-    firewall = NULL;
-  }
+    {
+      if(scamper_firewall_init(firewall) != 0)
+	return -1;
+      free(firewall);
+      firewall = NULL;
+    }
 
 #ifndef WITHOUT_DEBUGFILE
   /*
-   * open the debug file immediately so initialization debugging information
+   * open the debug file immediately so initialisation debugging information
    * makes it to the file
    */
   if(debugfile != NULL && scamper_debug_open(debugfile) != 0)
-  {
+    {
       return -1;
-  }
+    }
 #endif
 
   /* determine a suitable default value for the source port in packets */
@@ -1254,9 +1254,9 @@ static int scamper(int argc, char *argv[])
 
   /* allocate the cache of addresses for scamper to keep track of */
   if((addrcache = scamper_addrcache_alloc()) == NULL)
-  {
+    {
       return -1;
-  }
+    }
 
   /* init the probing code */
   if(scamper_probe_init() != 0)
@@ -1268,67 +1268,70 @@ static int scamper(int argc, char *argv[])
 
   /* setup the file descriptor monitoring code */
   if(scamper_fds_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
   if(options & (OPT_CTRL_INET|OPT_CTRL_UNIX|OPT_CTRL_REMOTE))
-  {
-    if(scamper_control_init() != 0)
-	  return -1;
-    if(options & OPT_CTRL_INET && scamper_control_add_inet(ctrl_inet_addr, ctrl_inet_port) != 0)
-	  return -1;
-    if(options & OPT_CTRL_UNIX && scamper_control_add_unix(ctrl_unix) != 0)
-	  return -1;
-    if(options & OPT_CTRL_REMOTE && scamper_control_add_remote(ctrl_rem_name, ctrl_rem_port) != 0)
-	  return -1;
+    {
+      if(scamper_control_init() != 0)
+	return -1;
+      if(options & OPT_CTRL_INET &&
+	 scamper_control_add_inet(ctrl_inet_addr, ctrl_inet_port) != 0)
+	return -1;
+      if(options & OPT_CTRL_UNIX &&
+	 scamper_control_add_unix(ctrl_unix) != 0)
+	return -1;
+      if(options & OPT_CTRL_REMOTE &&
+	 scamper_control_add_remote(ctrl_rem_name, ctrl_rem_port) != 0)
+	return -1;
 
-    /* wait for more tasks when finished with the active window */
-    exit_when_done = 0;
-  }
+      /* wait for more tasks when finished with the active window */
+      exit_when_done = 0;
+    }
 
-  /* initialize the subsystem responsible for obtaining source addresses */
+  /* initialise the subsystem responsible for obtaining source addresses */
   if(scamper_getsrc_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
-  /* initialize the subsystem responsible for recording MAC addresses */
+  /* initialise the subsystem responsible for recording mac addresses */
   if(scamper_addr2mac_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
   if(scamper_rtsock_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
-  /* initialize the structures necessary to keep track of addresses to probe */
+  /* initialise the structures necessary to keep track of addresses to probe */
   if(scamper_sources_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
   /*
-   * initialize the data structures necessary to keep track of the signatures
+   * initialise the data structures necessary to keep track of the signatures
    * of tasks currently being probed
    */
   if(scamper_task_init() == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
   /*
-   * initialize the data structures necessary to keep track of output files
+   * initialise the data structures necessary to keep track of output files
    * currently being written to
    */
   if(scamper_outfiles_init(outfile, outtype) == -1)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
-  /* initialize scamper so it is ready to traceroute and ping */
+  /* initialise scamper so it is ready to traceroute and ping */
   if(scamper_do_trace_init() != 0 ||
      scamper_do_traceb_init() != 0 ||
      scamper_do_ping_init() != 0 ||
@@ -1339,9 +1342,9 @@ static int scamper(int argc, char *argv[])
      scamper_do_tbit_init() != 0 ||
      scamper_do_sniff_init() != 0 ||
      scamper_do_host_init() != 0)
-  {
-    return -1;
-  }
+    {
+      return -1;
+    }
 
   /* parameters for the default list */
   memset(&ssp, 0, sizeof(ssp));
@@ -1361,160 +1364,154 @@ static int scamper(int argc, char *argv[])
    * read the addresses now
    */
   if(options & (OPT_IP|OPT_CMDLIST))
-  {
-    if((source = scamper_source_cmdline_alloc(&ssp, command,
-                   arglist, arglist_len)) == NULL)
     {
-      return -1;
+      if((source = scamper_source_cmdline_alloc(&ssp, command,
+						arglist, arglist_len)) == NULL)
+	{
+	  return -1;
+	}
     }
-  }
   else if((options & (OPT_CTRL_INET|OPT_CTRL_UNIX|OPT_CTRL_REMOTE)) == 0)
-  {
-    if(intype == NULL)
-      source = scamper_source_file_alloc(&ssp, arglist[0], command, 1, 0);
-    else if(strcasecmp(intype, "tsps") == 0)
-     source = scamper_source_tsps_alloc(&ssp, arglist[0]);
-    else if(strcasecmp(intype, "cmdfile") == 0)
-      source = scamper_source_file_alloc(&ssp, arglist[0], NULL, 1, 0);
-    if(source == NULL)
     {
-      return -1;
+      if(intype == NULL)
+	source = scamper_source_file_alloc(&ssp, arglist[0], command, 1, 0);
+      else if(strcasecmp(intype, "tsps") == 0)
+	source = scamper_source_tsps_alloc(&ssp, arglist[0]);
+      else if(strcasecmp(intype, "cmdfile") == 0)
+	source = scamper_source_file_alloc(&ssp, arglist[0], NULL, 1, 0);
+      if(source == NULL)
+	return -1;
     }
-  }
 
   if(source != NULL)
-  {
-    scamper_sources_add(source);
-    scamper_source_free(source);
-  }
+    {
+      scamper_sources_add(source);
+      scamper_source_free(source);
+    }
 
   gettimeofday_wrap(&lastprobe);
 
   for(;;)
-  {
-    if((rc = scamper_timeout(&timeout, &nextprobe, &lastprobe)) == 0)
     {
-      /*
-       * we've been told to calculate a timeout value.  figure out what
-       * it should be.
-       */
-      gettimeofday_wrap(&tv);
-      if(timeval_cmp(&timeout, &tv) <= 0)
-        memset(&tv, 0, sizeof(tv));
+      if((rc = scamper_timeout(&timeout, &nextprobe, &lastprobe)) == 0)
+	{
+	  /*
+	   * we've been told to calculate a timeout value.  figure out what
+	   * it should be.
+	   */
+	  gettimeofday_wrap(&tv);
+	  if(timeval_cmp(&timeout, &tv) <= 0)
+	    memset(&tv, 0, sizeof(tv));
+	  else
+	    timeval_diff_tv(&tv, &tv, &timeout);
+	  timeout_ptr = &tv;
+	}
+      else if(rc == 1)
+	{
+	  timeout_ptr = NULL;
+	}
       else
-        timeval_diff_tv(&tv, &tv, &timeout);
-      timeout_ptr = &tv;
-    }
-    else if(rc == 1)
-    {
-      timeout_ptr = NULL;
-    }
-    else
-    {
-      /* exit when done */
-      break;
+	{
+	  /* exit when done */
+	  break;
 	}
 
-    /* listen until it is time to send the next probe */
-    if(scamper_fds_poll(timeout_ptr) == -1)
-    {
-      return -1;
-    }
+      /* listen until it is time to send the next probe */
+      if(scamper_fds_poll(timeout_ptr) == -1)
+	return -1;
 
-    /* get the current time */
-    gettimeofday_wrap(&tv);
+      /* get the current time */
+      gettimeofday_wrap(&tv);
 
-    if(scamper_queue_event_proc(&tv) != 0)
-    {
-      return -1;
-    }
+      if(scamper_queue_event_proc(&tv) != 0)
+	return -1;
+      
+      /* take any 'done' tasks and output them now */
+      while((task = scamper_queue_getdone(&tv)) != NULL)
+	{
+	  /* write the data out */
+	  if((source = scamper_task_getsource(task)) != NULL &&
+	     (sofname = scamper_source_getoutfile(source)) != NULL &&
+	     (sof = scamper_outfiles_get(sofname)) != NULL)
+	    {
+	      file = scamper_outfile_getfile(sof);
+	      scamper_task_write(task, file);
 
-    /* take any 'done' tasks and output them now */
-    while((task = scamper_queue_getdone(&tv)) != NULL)
-    {
-      /* write the data out */
-      if((source = scamper_task_getsource(task)) != NULL &&
-         (sofname = scamper_source_getoutfile(source)) != NULL &&
-         (sof = scamper_outfiles_get(sofname)) != NULL)
-      {
-        file = scamper_outfile_getfile(sof);
-        scamper_task_write(task, file);
+	      /*
+	       * write a copy of the data out if asked to, and it has not
+	       * already been written to this output file.
+	       */
+	      if((flags & FLAG_OUTCOPY) != 0 &&
+		 (sof2 = scamper_outfiles_get(NULL)) != NULL && sof != sof2)
+		{
+		  file = scamper_outfile_getfile(sof2);
+		  scamper_task_write(task, file);
+		}
+	    }
 
-        /*
-         * write a copy of the data out if asked to, and it has not
-         * already been written to this output file.
-         */
-        if((flags & FLAG_OUTCOPY) != 0 &&
-           (sof2 = scamper_outfiles_get(NULL)) != NULL && sof != sof2)
-        {
-          file = scamper_outfile_getfile(sof2);
-          scamper_task_write(task, file);
-        }
-      }
-
-      /* cleanup the task */
-      scamper_task_free(task);
-    }
-
-    /*
-     * if there is something waiting to be probed, then find out if it is
-     * time to probe yet
-     */
-    if(scamper_queue_readycount() > 0 || scamper_sources_isready() == 1)
-    {
-      /*
-       * check for large differences between the time the last probe
-       * was sent and the current time.  don't allow the difference to
-       * be larger than a particular amount, since that could result in
-       * either a large flutter of probes to be sent, or a large time
-       * before the next probe is sent
-       */
-      if(timeval_inrange_us(&tv, &lastprobe, probe_window) == 0)
-        timeval_sub_us(&lastprobe, &tv, wait_between);
+	  /* cleanup the task */
+	  scamper_task_free(task);
+	}
 
       /*
-       * when probing at > HZ, scamper might find that select blocks it
-       * from achieving the specified packets per second rate if it sends
-       * one probe per select.  Based on the time spent in the last call
-       * to select, send the necessary number of packets to fill that
-       * window where we sent no packets.
+       * if there is something waiting to be probed, then find out if it is
+       * time to probe yet
        */
-      for(;;)
-      {
-        timeval_add_us(&nextprobe, &lastprobe, wait_between);
+      if(scamper_queue_readycount() > 0 || scamper_sources_isready() == 1)
+	{
+	  /*
+	   * check for large differences between the time the last probe
+	   * was sent and the current time.  don't allow the difference to
+	   * be larger than a particular amount, since that could result in
+	   * either a large flutter of probes to be sent, or a large time
+	   * before the next probe is sent
+	   */
+	  if(timeval_inrange_us(&tv, &lastprobe, probe_window) == 0)
+	    timeval_sub_us(&lastprobe, &tv, wait_between);
 
-        /* if the next probe is not due to be sent, don't send one */
-        if(timeval_cmp(&nextprobe, &tv) > 0)
-          break;
+	  /*
+	   * when probing at > HZ, scamper might find that select blocks it
+	   * from achieving the specified packets per second rate if it sends
+	   * one probe per select.  Based on the time spent in the last call
+	   * to select, send the necessary number of packets to fill that
+	   * window where we sent no packets.
+	   */
+	  for(;;)
+	    {
+	      timeval_add_us(&nextprobe, &lastprobe, wait_between);
 
-        /*
-         * look for an address that we can send a probe to.  if
-         * scamper doesn't have a task on the probe queue waiting
-         * to be probed, then get a fresh task. if there's absolutely
-         * nothing that scamper can probe, then break.
-         */
-        if((task = scamper_queue_select()) == NULL)
-        {
-          /*
-           * if we are already probing to the window limit, don't
-           * add any new tasks
-           */
-          if(window != 0 && scamper_queue_windowcount() >= window)
-            break;
+	      /* if the next probe is not due to be sent, don't send one */
+	      if(timeval_cmp(&nextprobe, &tv) > 0)
+		break;
 
-          /*
-           * if there are no more tasks ready to be added yet, there's
-           * nothing more to be done in the loop
-           */
-          if(scamper_sources_gettask(&task) != 0 || task == NULL)
-            break;
-        }
+	      /*
+	       * look for an address that we can send a probe to.  if
+	       * scamper doesn't have a task on the probe queue waiting
+	       * to be probed, then get a fresh task. if there's absolutely
+	       * nothing that scamper can probe, then break.
+	       */
+	      if((task = scamper_queue_select()) == NULL)
+		{
+		  /*
+		   * if we are already probing to the window limit, don't
+		   * add any new tasks
+		   */
+		  if(window != 0 && scamper_queue_windowcount() >= window)
+		    break;
 
-        scamper_task_probe(task);
-        timeval_cpy(&lastprobe, &nextprobe);
-      }
+		  /*
+		   * if there are no more tasks ready to be added yet, there's
+		   * nothing more to be done in the loop
+		   */
+		  if(scamper_sources_gettask(&task) != 0 || task == NULL)
+		    break;
+		}
+
+	      scamper_task_probe(task);
+	      timeval_cpy(&lastprobe, &nextprobe);
+	    }
+	}
     }
-  }
 
   return 0;
 }

--- a/scamper/scamper_file.c
+++ b/scamper/scamper_file.c
@@ -182,6 +182,7 @@ static struct handler handlers[] = {
    NULL,                                   /* init_append */
    scamper_file_arts_read,                 /* read */
    NULL,                                   /* write_trace */
+   NULL,                                   /* write_traceb */
    NULL,                                   /* write_cycle_start */
    NULL,                                   /* write_cycle_stop */
    NULL,                                   /* write_ping */
@@ -201,6 +202,7 @@ static struct handler handlers[] = {
    scamper_file_warts_init_append,         /* init_append */
    scamper_file_warts_read,                /* read */
    scamper_file_warts_trace_write,         /* write_trace */
+   NULL,                                   /* write_traceb */
    scamper_file_warts_cyclestart_write,    /* write_cycle_start */
    scamper_file_warts_cyclestop_write,     /* write_cycle_stop */
    scamper_file_warts_ping_write,          /* write_ping */
@@ -220,6 +222,7 @@ static struct handler handlers[] = {
    NULL,                                   /* init_append */
    NULL,                                   /* read */
    scamper_file_json_trace_write,          /* write_trace */
+   NULL,                                   /* write_traceb */
    scamper_file_json_cyclestart_write,     /* write_cycle_start */
    scamper_file_json_cyclestop_write,      /* write_cycle_stop */
    scamper_file_json_ping_write,           /* write_ping */
@@ -315,7 +318,7 @@ int scamper_file_write_traceb(scamper_file_t *sf, const struct scamper_traceb *t
     rc = handlers[sf->type].write_traceb(sf, trace);
   }
 
-  return rc;
+  return rc; 
 }
 
 int scamper_file_write_ping(scamper_file_t *sf,

--- a/scamper/scamper_source_cmdline.c
+++ b/scamper/scamper_source_cmdline.c
@@ -41,45 +41,45 @@ static const char rcsid[] =
 #include "utils.h"
 
 static int command_assemble(char **out, size_t *len,
-                            const char *cmd, size_t cmdlen, const char *addr)
+			    const char *cmd, size_t cmdlen, const char *addr)
 {
   size_t addrlen = strlen(addr);
   size_t reqlen = cmdlen + 1 + addrlen + 1;
   char  *tmp;
 
   if(reqlen > *len)
-  {
-    if(*len != 0)
     {
-      if((tmp = realloc(*out, reqlen)) == NULL)
-      {
-        printerror(__func__, "could not realloc %d bytes", reqlen);
-        return -1;
-      }
-    }
-    else
-    {
-      if((tmp = malloc_zero(reqlen)) == NULL)
-      {
-        printerror(__func__, "could not malloc %d bytes", reqlen);
-        return -1;
-      }
+      if(*len != 0)
+	{
+	  if((tmp = realloc(*out, reqlen)) == NULL)
+	    {
+	      printerror(__func__, "could not realloc %d bytes", reqlen);
+	      return -1;
+	    }
+	}
+      else
+	{
+	  if((tmp = malloc_zero(reqlen)) == NULL)
+	    {
+	      printerror(__func__, "could not malloc %d bytes", reqlen);
+	      return -1;
+	    }
 
-      memcpy(tmp, cmd, cmdlen);
-      tmp[cmdlen] = ' ';
-    }
+	  memcpy(tmp, cmd, cmdlen);
+	  tmp[cmdlen] = ' ';
+	}
 
-    *out = tmp;
-    *len = reqlen;
-  }
+      *out = tmp;
+      *len = reqlen;
+    }
 
   memcpy((*out)+cmdlen+1, addr, addrlen + 1);
-
   return 0;
 }
 
 scamper_source_t *scamper_source_cmdline_alloc(scamper_source_params_t *ssp,
-                                               const char *cmd, char **arg, int arg_cnt)
+					       const char *cmd,
+					       char **arg, int arg_cnt)
 {
   scamper_source_t *source = NULL;
   size_t cmd_len, len = 0;
@@ -89,30 +89,30 @@ scamper_source_t *scamper_source_cmdline_alloc(scamper_source_params_t *ssp,
   ssp->type = SCAMPER_SOURCE_TYPE_CMDLINE;
 
   if((source = scamper_source_alloc(ssp)) == NULL)
-  {
-    goto err;
-  }
+    {
+      goto err;
+    }
 
   if(cmd != NULL)
-  {
-    cmd_len = strlen(cmd);
-    for(i=0; i<arg_cnt; i++)
     {
-      if(command_assemble(&buf, &len, cmd, cmd_len, arg[i]) != 0 ||
-         scamper_source_command(source, buf) != 0)
-      {
-        goto err;
-      }
+      cmd_len = strlen(cmd);
+      for(i=0; i<arg_cnt; i++)
+	{
+	  if(command_assemble(&buf, &len, cmd, cmd_len, arg[i]) != 0 ||
+	     scamper_source_command(source, buf) != 0)
+	    {
+	      goto err;
+	    }
+	}
     }
-  }
   else
-  {
-    for(i=0; i<arg_cnt; i++)
     {
-      if(scamper_source_command(source, arg[i]) != 0)
-        goto err;
+      for(i=0; i<arg_cnt; i++)
+	{
+	  if(scamper_source_command(source, arg[i]) != 0)
+	    goto err;
+	}
     }
-  }
 
   if(buf != NULL)
     free(buf);

--- a/scamper/scamper_sources.c
+++ b/scamper/scamper_sources.c
@@ -1327,14 +1327,14 @@ static const command_func_t *command_func_get(const char *command)
   size_t i;
 
   for(i=0; i<command_funcc; i++)
-  {
+    {
       func = &command_funcs[i];
       if(strncasecmp(command, func->command, func->len) == 0 &&
-          isspace((int)command[func->len]) && command[func->len] != '\0')
-      {
-        return func;
-      }
-  }
+	 isspace((int)command[func->len]) && command[func->len] != '\0')
+	{
+	  return func;
+	}
+    }
 
   return NULL;
 }
@@ -1349,12 +1349,11 @@ static void *command_func_allocdata(const command_func_t *f, const char *cmd)
 {
   char *opts = NULL;
   void *data;
-
   if((opts = strdup(cmd + f->len)) == NULL)
-  {
-    printerror(__func__, "could not strdup cmd opts");
-    return NULL;
-  }
+    {
+      printerror(__func__, "could not strdup cmd opts");
+      return NULL;
+    }
   data = f->allocdata(opts);
   free(opts);
   return data;
@@ -1890,62 +1889,61 @@ int scamper_sources_gettask(scamper_task_t **task)
     source_next();
 
   while((source = source_cur) != NULL)
-  {
-    assert(source->priority > 0);
-
-    while((command = dlist_head_pop(source->commands)) != NULL)
     {
+      assert(source->priority > 0);
 
-      if(source->take != NULL)
-        source->take(source->data);
+      while((command = dlist_head_pop(source->commands)) != NULL)
+	{
+	  if(source->take != NULL)
+	    source->take(source->data);
 
-      switch(command->type)
-      {
-        case COMMAND_PROBE:
-          if(command_probe_handle(source, command, task) != 0)
-            goto err;
-          if(*task == NULL)
-            continue;
-          source_cnt++;
-          goto done;
+	  switch(command->type)
+	    {
+	    case COMMAND_PROBE:
+	      if(command_probe_handle(source, command, task) != 0)
+		goto err;
+	      if(*task == NULL)
+		continue;
+	      source_cnt++;
+	      goto done;
 
-        case COMMAND_TASK:
-          if(command_task_handle(source, command, task) != 0)
-            goto err;
-          if(*task == NULL)
-            continue;
-          source_cnt++;
-          goto done;
+	    case COMMAND_TASK:
+	      if(command_task_handle(source, command, task) != 0)
+		goto err;
+	      if(*task == NULL)
+		continue;
+	      source_cnt++;
+	      goto done;
 
-        case COMMAND_CYCLE:
-          command_cycle_handle(source, command);
-          break;
+	    case COMMAND_CYCLE:
+	      command_cycle_handle(source, command);
+	      break;
 
-        default:
-          goto err;
-      }
+	    default:
+	      goto err;
+	    }
+	}
+
+      /* the previous source could not supply a command */
+      assert(dlist_count(source->commands) == 0);
+
+      /*
+       * if the source is not yet finished, put it on the blocked list;
+       * otherwise, the source is detached.
+       */
+      if(scamper_source_isfinished(source) == 0)
+	source_blocked_attach(source);
+      else
+	source_detach(source);
     }
-
-    /* the previous source could not supply a command */
-    assert(dlist_count(source->commands) == 0);
-
-    /*
-     * if the source is not yet finished, put it on the blocked list;
-     * otherwise, the source is detached.
-     */
-    if(scamper_source_isfinished(source) == 0)
-      source_blocked_attach(source);
-    else
-      source_detach(source);
-  }
 
   *task = NULL;
 
-done:
+ done:
   sources_assert();
   return 0;
 
-err:
+ err:
   sources_assert();
   return -1;
 }


### PR DESCRIPTION
A bug was introduced when the traceb command was added. Particularly, when adding a handler for writing its output in text format. This was done by adding a field to the handler struct defined in scamper/scamper_file.c.
The problem is that later on, an array of handler structs is declared and initialized with static values. These values assign each of the struct fields positionally, not by name. Therefore, when a new field was added, and only the first element of the array was updated, all the other elements were left in an invalid state: since they were not initializing the first field like the first element did, all the values were wrong. Sadly, the C compiler didn't warn or error on this.
This is how you shoot yourself in the foot! Luckily, testing the sc_ally util caught this in time. After merging, I recommend testing the issues about commands not giving output again, because those problems may have been caused by this bug.